### PR TITLE
Update @opencensus/web-types  with @opencensus/core (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Add support for object(`SpanOptions`) as an argument for `startChildSpan` function, similar to `startRootSpan`.
+
 ## 0.0.2 - 2019-04-29
 
 Fix: add JS bundles and source maps to the NPM files for @opencensus/web-all 

--- a/packages/opencensus-web-core/src/trace/model/root-span.ts
+++ b/packages/opencensus-web-core/src/trace/model/root-span.ts
@@ -23,6 +23,9 @@ export class RootSpan extends Span implements webTypes.RootSpan {
   /** A list of child spans. */
   spans: Span[] = [];
 
+  /** A number of children. */
+  private numberOfChildrenLocal: number;
+
   constructor(
     /** Trace associated with this root span. */
     private readonly tracer: webTypes.Tracer,
@@ -44,17 +47,26 @@ export class RootSpan extends Span implements webTypes.RootSpan {
     } else {
       this.traceId = randomTraceId();
     }
+
+    this.numberOfChildrenLocal = 0;
+  }
+
+  /** Gets the number of child span created for this span. */
+  get numberOfChildren(): number {
+    return this.numberOfChildrenLocal;
   }
 
   /**
    * Starts a new child span in the root span.
-   * @param nameOrOptions Span name string or object with `name` and `kind`
+   * @param nameOrOptions Span name string or SpanOptions object.
    * @param kind Span kind if not using options object.
+   * @param parentSpanId Span parent ID.
    */
   startChildSpan(
-    nameOrOptions?: string | { name: string; kind: webTypes.SpanKind },
+    nameOrOptions?: string | webTypes.SpanOptions,
     kind?: webTypes.SpanKind
   ): Span {
+    this.numberOfChildrenLocal++;
     const child = new Span();
     child.traceId = this.traceId;
     child.traceState = this.traceState;

--- a/packages/opencensus-web-core/src/trace/model/span.ts
+++ b/packages/opencensus-web-core/src/trace/model/span.ts
@@ -187,9 +187,17 @@ export class Span implements webTypes.Span {
   addMessageEvent(
     type: webTypes.MessageEventType,
     id: string,
-    timestamp: number = performance.now()
+    timestamp: number = performance.now(),
+    uncompressedSize?: number,
+    compressedSize?: number
   ) {
-    this.messageEvents.push({ type, id, timestamp });
+    this.messageEvents.push({
+      type,
+      id,
+      timestamp,
+      uncompressedSize,
+      compressedSize,
+    });
   }
 
   /**

--- a/packages/opencensus-web-core/src/trace/model/tracer.ts
+++ b/packages/opencensus-web-core/src/trace/model/tracer.ts
@@ -117,12 +117,15 @@ export class Tracer implements webTypes.Tracer {
 
   /**
    * Start a new Span instance to the currentRootSpan
-   * @param name Span name
+   * @param name Span name or SpanOptions object.
    * @param kind Span kind
    * @returns The new Span instance started
    */
-  startChildSpan(name?: string, kind?: webTypes.SpanKind): Span {
-    return this.currentRootSpan.startChildSpan(name, kind);
+  startChildSpan(
+    nameOrOptions?: string | webTypes.SpanOptions,
+    kind?: webTypes.SpanKind
+  ): Span {
+    return this.currentRootSpan.startChildSpan(nameOrOptions, kind);
   }
 
   /**

--- a/packages/opencensus-web-core/test/test-root-span.ts
+++ b/packages/opencensus-web-core/test/test-root-span.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SpanKind } from '@opencensus/web-types';
+import { SpanKind, SpanOptions } from '@opencensus/web-types';
 import { RootSpan } from '../src/trace/model/root-span';
 import { Tracer } from '../src/trace/model/tracer';
 
@@ -66,14 +66,15 @@ describe('RootSpan', () => {
       expect(root.spans).toEqual([childSpan]);
     });
 
-    it('allows specifying span options object with name and kind', () => {
+    it('allows specifying SpanOptions object with name and kind', () => {
       root.traceId = '00000000000000000000000000000001';
       root.traceState = 'a=b';
 
-      const childSpan = root.startChildSpan({
+      const spanOptions: SpanOptions = {
         name: 'child1',
         kind: SpanKind.CLIENT,
-      });
+      };
+      const childSpan = root.startChildSpan(spanOptions);
 
       expect(childSpan.traceId).toBe('00000000000000000000000000000001');
       expect(childSpan.traceState).toBe('a=b');
@@ -117,6 +118,21 @@ describe('RootSpan', () => {
 
       expect(root.endPerfTime).toBe(4);
       expect(tracer.onEndSpan).toHaveBeenCalledWith(root);
+    });
+  });
+
+  describe('get numberOfChildren()', () => {
+    it('should get numberOfChildren from rootspan instance', () => {
+      root = new RootSpan(tracer);
+      root.start();
+      expect(root.numberOfChildren).toBe(0);
+      root.startChildSpan('spanName', SpanKind.UNSPECIFIED);
+      expect(root.numberOfChildren).toBe(1);
+
+      for (let i = 0; i < 10; i++) {
+        root.startChildSpan('spanName' + i, SpanKind.UNSPECIFIED);
+      }
+      expect(root.numberOfChildren).toBe(11);
     });
   });
 });

--- a/packages/opencensus-web-core/test/test-span.ts
+++ b/packages/opencensus-web-core/test/test-span.ts
@@ -160,6 +160,8 @@ describe('Span', () => {
           type: MessageEventType.SENT,
           id: 'id22',
           timestamp: 25,
+          uncompressedSize: undefined,
+          compressedSize: undefined,
         },
       ]);
     });
@@ -173,6 +175,8 @@ describe('Span', () => {
           type: MessageEventType.RECEIVED,
           id: 'id23',
           timestamp: 33,
+          uncompressedSize: undefined,
+          compressedSize: undefined,
         },
       ]);
     });

--- a/packages/opencensus-web-types/package.json
+++ b/packages/opencensus-web-types/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run compile",
     "clean": "rimraf build/*",
-    "copytypes": "node scripts/copy-types.js 'v0.0.9' && npm run fix",
+    "copytypes": "node scripts/copy-types.js '36f63e6dee9e6ad9af5ece9c5458b47786d41f06' && npm run fix",
     "check": "gts check",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/packages/opencensus-web-types/src/exporters/types.ts
+++ b/packages/opencensus-web-types/src/exporters/types.ts
@@ -56,6 +56,9 @@ export interface StatsEventListener {
    * batched data to backend.
    */
   start(): void;
+
+  /** Stops the exporter. */
+  stop(): void;
 }
 
 export type ExporterConfig = configTypes.BufferConfig;

--- a/packages/opencensus-web-types/src/stats/types.ts
+++ b/packages/opencensus-web-types/src/stats/types.ts
@@ -96,6 +96,13 @@ export interface Stats {
    * @param exporter An stats exporter
    */
   registerExporter(exporter: StatsEventListener): void;
+
+  /**
+   * Unregisters an exporter. It should be called whenever the exporter is not
+   * needed anymore.
+   * @param exporter An stats exporter
+   */
+  unregisterExporter(exporter: StatsEventListener): void;
 }
 
 /**

--- a/packages/opencensus-web-types/src/trace/model/types.ts
+++ b/packages/opencensus-web-types/src/trace/model/types.ts
@@ -15,10 +15,10 @@
  */
 
 import * as loggerTypes from '../../common/types';
-import { NodeJsEventEmitter } from '../../node/types';
 import * as configTypes from '../config/types';
 import { Propagation } from '../propagation/types';
 import * as samplerTypes from '../sampler/types';
+import { NodeJsEventEmitter } from '../../node/types';
 
 /** Default type for functions */
 // tslint:disable:no-any
@@ -191,7 +191,13 @@ export interface MessageEvent {
   timestamp: number;
   /** Indicates whether the message was sent or received. */
   type: MessageEventType;
-  /** An identifier for the MessageEvent's message. */
+  /**
+   * An identifier for the MessageEvent's message. This should be a hexadecimal
+   * value that fits within 64-bits. Message event ids should start with 1 for
+   * both sent and received messages and increment by 1 for each message
+   * sent/received. See:
+   * https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/gRPC.md#message-events
+   */
   id: string;
   /** The number of uncompressed bytes sent or received. */
   uncompressedSize?: number;
@@ -225,6 +231,18 @@ export interface TraceOptions {
   spanContext?: SpanContext;
   /** Span kind */
   kind?: SpanKind;
+  /** Determines the sampling rate. Ranges from 0.0 to 1.0 */
+  samplingRate?: number;
+}
+
+/** Defines the span options */
+export interface SpanOptions {
+  /** Span name */
+  name: string;
+  /** Span kind */
+  kind?: SpanKind;
+  /** Span parent ID */
+  parentSpanId?: string;
 }
 
 export type TraceState = string;
@@ -417,8 +435,17 @@ export interface Span {
    * @param type The type of message event.
    * @param id An identifier for the message event.
    * @param timestamp A timestamp for this event.
+   * @param uncompressedSize The number of uncompressed bytes sent or received.
+   * @param compressedSize The number of compressed bytes sent or received. If
+   *     zero or undefined, assumed to be the same size as uncompressed.
    */
-  addMessageEvent(type: MessageEventType, id: string, timestamp?: number): void;
+  addMessageEvent(
+    type: MessageEventType,
+    id: string,
+    timestamp?: number,
+    uncompressedSize?: number,
+    compressedSize?: number
+  ): void;
 
   /**
    * Sets a status to the span.
@@ -442,8 +469,13 @@ export interface RootSpan extends Span {
   /** Get the span list from RootSpan instance */
   readonly spans: Span[];
 
+  /** Gets the number of child span created for this span. */
+  readonly numberOfChildren: number;
+
   /** Starts a new Span instance in the RootSpan instance */
-  startChildSpan(name: string, kind: SpanKind): Span;
+  startChildSpan(name?: string, kind?: SpanKind): Span;
+  startChildSpan(options?: SpanOptions): Span;
+  startChildSpan(nameOrOptions?: string | SpanOptions, kind?: SpanKind): Span;
 }
 
 /** Interface for Tracer */
@@ -505,11 +537,12 @@ export interface Tracer extends SpanEventListener {
   /**
    * Start a new Span instance to the currentRootSpan
    * @param name Span name
-   * @param type Span type
-   * @param parentSpanId Parent SpanId
+   * @param kind Span kind
+   * @param options Span Options
    * @returns The new Span instance started
    */
-  startChildSpan(name?: string, type?: SpanKind, parentSpanId?: string): Span;
+  startChildSpan(name?: string, kind?: SpanKind): Span;
+  startChildSpan(options?: SpanOptions): Span;
 
   /**
    * Binds the trace context to the given function.


### PR DESCRIPTION
* Add option of passing in an object to the createChildSpan.

* Add support for child span count.

* Update types to add support for unregister stats exporter.

* update CHANGELOG

* Sync with @opencensus/core commit 36f63e6d.

* Fix Root Span tests.